### PR TITLE
Redesign layout for symmetrical style

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,9 +32,9 @@
 <body class="bg-white text-slate-800 dark:bg-slate-900 dark:text-slate-100">
   <!-- Navbar -->
   <header class="sticky top-0 z-50 backdrop-blur supports-[backdrop-filter]:bg-white/70 dark:supports-[backdrop-filter]:bg-slate-900/70 border-b border-slate-200/60 dark:border-slate-700/60">
-    <div class="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
+    <div class="max-w-6xl mx-auto px-4 py-3 flex flex-col items-center gap-4">
       <a href="#home" class="font-extrabold tracking-tight text-xl">Visarn  <span class="text-gradient">Portfolio</span></a>
-      <nav class="hidden md:flex gap-6 text-sm">
+      <nav class="flex gap-6 text-sm">
         <a href="#about" class="hover:opacity-70">เกี่ยวกับฉัน</a>
         <a href="#projects" class="hover:opacity-70">โปรเจกต์</a>
         <a href="#skills" class="hover:opacity-70">ทักษะ</a>
@@ -44,37 +44,30 @@
         <button id="themeToggle" class="rounded-xl px-3 py-2 border border-slate-300 dark:border-slate-700 text-xs hover:shadow-soft">
           โหมดมืด
         </button>
-        <button class="md:hidden rounded-xl p-2 border border-slate-300 dark:border-slate-700" id="menuBtn" aria-label="Open menu">
-          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-5 h-5 fill-none stroke-current"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16"/></svg>
-        </button>
       </div>
-    </div>
-    <div id="mobileMenu" class="md:hidden hidden border-t border-slate-200/60 dark:border-slate-700/60">
-      <nav class="max-w-6xl mx-auto px-4 py-3 grid gap-3 text-sm">
-        <a href="#about" class="py-2">เกี่ยวกับฉัน</a>
-        <a href="#projects" class="py-2">โปรเจกต์</a>
-        <a href="#skills" class="py-2">ทักษะ</a>
-        <a href="#contact" class="py-2">ติดต่อ</a>
-      </nav>
     </div>
   </header>
 
   <!-- Hero -->
   <section id="home" class="relative overflow-hidden">
     <div class="accent absolute inset-0 opacity-[0.07] pointer-events-none"></div>
-    <div class="max-w-6xl mx-auto px-4 py-20 md:py-28 grid md:grid-cols-2 gap-10 items-center">
+    <div class="max-w-6xl mx-auto px-4 py-20 md:py-28 flex flex-col items-center text-center gap-10">
+      <div class="relative">
+        <div class="w-64 h-64 md:w-80 md:h-80 rounded-full accent opacity-90 shadow-soft mx-auto"></div>
+        <img src="./assets/img/profile/profile.png" alt="Profile" class="w-48 h-48 md:w-60 md:h-60 rounded-full object-cover shadow-2xl absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 ring-8 ring-white dark:ring-slate-900" />
+      </div>
       <div>
         <p class="text-sm uppercase tracking-widest text-slate-500 dark:text-slate-400">Hello, I'm</p>
         <h1 class="text-4xl md:text-6xl font-extrabold leading-tight mt-2">Visarn Srisanguanvilas</h1>
         <p class="mt-4 text-lg text-slate-600 dark:text-slate-300">Software Developer Student — Frontend • Backend • UX/UI</p>
-        <div class="mt-6 flex flex-wrap gap-3">
+        <div class="mt-6 flex flex-wrap gap-3 justify-center">
           <a href="#projects" class="inline-flex items-center gap-2 rounded-2xl px-5 py-3 bg-slate-900 text-white dark:bg-white dark:text-slate-900 shadow-soft">
             ดูโปรเจกต์
             <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" class="w-4 h-4 fill-none stroke-current"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 12h14M12 5l7 7-7 7"/></svg>
           </a>
           <a href="#contact" class="inline-flex items-center gap-2 rounded-2xl px-5 py-3 border border-slate-300 dark:border-slate-700">ติดต่อฉัน</a>
         </div>
-        <div class="mt-6 flex gap-4 text-slate-500">
+        <div class="mt-6 flex gap-4 text-slate-500 justify-center">
           <!-- Social links -->
           <a href="tel:0945276645" class="hover:text-slate-900 dark:hover:text-white" aria-label="Phone">
             <svg class="w-6 h-6" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M6.62 10.79a15.053 15.053 0 006.59 6.59l2.2-2.2a1 1 0 011.02-.24c1.12.37 2.33.57 3.57.57a1 1 0 011 1V21a1 1 0 01-1 1C10.85 22 2 13.15 2 2a1 1 0 011-1h3.5a1 1 0 011 1c0 1.24.2 2.45.57 3.57a1 1 0 01-.24 1.02l-2.2 2.2z"/></svg>
@@ -82,48 +75,37 @@
           <a href="https://github.com/visarnvill1114" class="hover:text-slate-900 dark:hover:text-white" aria-label="GitHub">
             <svg class="w-6 h-6" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path fill-rule="evenodd" d="M12 2a10 10 0 00-3.162 19.492c.5.092.683-.217.683-.483 0-.237-.009-.866-.014-1.7-2.779.603-3.366-1.34-3.366-1.34-.454-1.154-1.11-1.462-1.11-1.462-.908-.621.069-.608.069-.608 1.004.071 1.532 1.032 1.532 1.032.893 1.53 2.341 1.088 2.91.833.091-.647.35-1.088.636-1.338-2.22-.252-4.555-1.11-4.555-4.942 0-1.091.39-1.985 1.029-2.683-.103-.253-.446-1.27.098-2.648 0 0 .84-.269 2.75 1.025A9.564 9.564 0 0112 6.844c.85.004 1.705.115 2.503.337 1.909-1.294 2.748-1.025 2.748-1.025.545 1.378.202 2.395.1 2.648.64.698 1.028 1.592 1.028 2.683 0 3.842-2.338 4.687-4.566 4.935.359.309.678.92.678 1.855 0 1.339-.012 2.419-.012 2.749 0 .268.18.58.688.481A10 10 0 0012 2z" clip-rule="evenodd"/></svg>
           </a>
-          
           <a href="mailto:visarnvill11@gmail.com" class="hover:text-slate-900 dark:hover:text-white" aria-label="Email">
             <svg class="w-6 h-6" viewBox="0 0 24 24" fill="currentColor"><path d="M12 13.065L.015 4.5h23.97L12 13.065zM12 15.3l-12-9V21h24V6.3l-12 9z"/></svg>
           </a>
         </div>
-      </div>
-      <div class="relative">
-        <div class="w-64 h-64 md:w-80 md:h-80 rounded-3xl accent opacity-90 shadow-soft mx-auto"></div>
-        <img src="./assets/img/profile/profile.png" alt="Profile" class="w-48 h-48 md:w-60 md:h-60 rounded-3xl object-cover shadow-2xl absolute -bottom-6 -right-6 ring-8 ring-white dark:ring-slate-900" />
       </div>
     </div>
   </section>
 
   <!-- About -->
   <section id="about" class="py-16 md:py-24">
-    <div class="max-w-6xl mx-auto px-4 grid md:grid-cols-3 gap-10">
+    <div class="max-w-4xl mx-auto px-4 text-center grid gap-10">
       <div>
         <h2 class="text-2xl md:text-3xl font-extrabold">เกี่ยวกับฉัน</h2>
         <p class="mt-3 text-slate-600 dark:text-slate-300">Motivated software developer student passionate about creating innovative solutions. Looking for opportunities to apply my knowledge in software development, with strong interests in frontend, backend, and UX/UI design.</p>
       </div>
-      <div class="md:col-span-2 grid gap-6">
-        <div class="p-6 rounded-2xl border border-slate-200 dark:border-slate-700">
-          <h3 class="font-semibold">การศึกษา</h3>
-          <ul class="mt-3 grid gap-2 list-disc list-inside text-slate-600 dark:text-slate-300">
-            <li><span class="font-medium">Bachelor of Engineering Program in Computer Engineering</span><br/>Mae Fah Luang University (2565 – Now)</li>
-            <li><span class="font-medium">High School Diploma (Science–Math Program)</span><br/>Samakkhiwittayakhom School (2558 – 2564)</li>
-          </ul>
-        </div>
+      <div class="p-6 rounded-2xl border border-slate-200 dark:border-slate-700 text-left">
+        <h3 class="font-semibold text-center">การศึกษา</h3>
+        <ul class="mt-3 grid gap-2 list-disc list-inside text-slate-600 dark:text-slate-300">
+          <li><span class="font-medium">Bachelor of Engineering Program in Computer Engineering</span><br/>Mae Fah Luang University (2565 – Now)</li>
+          <li><span class="font-medium">High School Diploma (Science–Math Program)</span><br/>Samakkhiwittayakhom School (2558 – 2564)</li>
+        </ul>
       </div>
     </div>
   </section>
 
   <!-- Projects -->
   <section id="projects" class="py-16 md:py-24 bg-slate-50 dark:bg-slate-950/30">
-    <div class="max-w-6xl mx-auto px-4">
-      <div class="flex items-end justify-between gap-4">
-        <div>
-          <h2 class="text-2xl md:text-3xl font-extrabold">โปรเจกต์เด่น</h2>
-          <p class="mt-2 text-slate-600 dark:text-slate-300">ตัวอย่างงานจริง/งานฝึกซ้อม พร้อมลิงก์ไปยัง GitHub</p>
-        </div>
-        <a href="https://github.com/visarnvill1114?tab=repositories" class="text-sm underline">ดูทั้งหมดบน GitHub →</a>
-      </div>
+    <div class="max-w-6xl mx-auto px-4 text-center">
+      <h2 class="text-2xl md:text-3xl font-extrabold">โปรเจกต์เด่น</h2>
+      <p class="mt-2 text-slate-600 dark:text-slate-300">ตัวอย่างงานจริง/งานฝึกซ้อม พร้อมลิงก์ไปยัง GitHub</p>
+      <a href="https://github.com/visarnvill1114?tab=repositories" class="mt-4 inline-block text-sm underline">ดูทั้งหมดบน GitHub →</a>
 
       <!-- Edit projects here -->
       <div class="mt-8 grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
@@ -182,9 +164,9 @@
 
   <!-- Skills -->
   <section id="skills" class="py-16 md:py-24">
-    <div class="max-w-6xl mx-auto px-4">
+    <div class="max-w-6xl mx-auto px-4 text-center">
       <h2 class="text-2xl md:text-3xl font-extrabold">ทักษะเด่น</h2>
-      <div class="mt-6 flex flex-wrap gap-2 text-sm">
+      <div class="mt-6 flex flex-wrap gap-2 justify-center text-sm">
         <span class="px-3 py-1 rounded-full bg-slate-100 dark:bg-slate-800">Frontend Development</span>
         <span class="px-3 py-1 rounded-full bg-slate-100 dark:bg-slate-800">Backend Development</span>
         <span class="px-3 py-1 rounded-full bg-slate-100 dark:bg-slate-800">UX/UI Design</span>
@@ -194,24 +176,23 @@
 
   <!-- Contact -->
   <section id="contact" class="py-16 md:py-24 bg-slate-50 dark:bg-slate-950/30">
-    <div class="max-w-6xl mx-auto px-4 grid md:grid-cols-2 gap-10 items-center">
+    <div class="max-w-4xl mx-auto px-4 grid gap-10 text-center">
       <div>
         <h2 class="text-2xl md:text-3xl font-extrabold">ติดต่อ</h2>
         <p class="mt-2 text-slate-600 dark:text-slate-300">ติดต่อทางอีเมลหรือช่องทางด้านล่างนี้</p>
-        <div class="mt-6 p-6 rounded-2xl border border-slate-200 dark:border-slate-700 grid gap-3">
-          <div>
-            <p class="text-sm text-slate-600 dark:text-slate-300">อีเมล</p>
-            <a class="text-lg underline" href="mailto:visarnvill11@gmail.com">visarnvill11@gmail.com</a>
-          </div>
-          <div>
-            <p class="text-sm text-slate-600 dark:text-slate-300">โทร</p>
-            <a class="text-lg underline" href="tel:0945276645">094 527 6645</a>
-          </div>
-          <div class="flex gap-4 pt-2 text-slate-600 dark:text-slate-300">
-            <a class="underline" href="https://github.com/visarnvill1114">GitHub</a>
-            
-            <a class="underline" href="#home">กลับขึ้นด้านบน</a>
-          </div>
+      </div>
+      <div class="p-6 rounded-2xl border border-slate-200 dark:border-slate-700 grid gap-3 text-left">
+        <div>
+          <p class="text-sm text-slate-600 dark:text-slate-300">อีเมล</p>
+          <a class="text-lg underline" href="mailto:visarnvill11@gmail.com">visarnvill11@gmail.com</a>
+        </div>
+        <div>
+          <p class="text-sm text-slate-600 dark:text-slate-300">โทร</p>
+          <a class="text-lg underline" href="tel:0945276645">094 527 6645</a>
+        </div>
+        <div class="flex gap-4 pt-2 text-slate-600 dark:text-slate-300 justify-center">
+          <a class="underline" href="https://github.com/visarnvill1114">GitHub</a>
+          <a class="underline" href="#home">กลับขึ้นด้านบน</a>
         </div>
       </div>
       <div class="p-6 rounded-2xl border border-slate-200 dark:border-slate-700">
@@ -223,9 +204,9 @@
   </section>
 
   <footer class="py-10">
-    <div class="max-w-6xl mx-auto px-4 flex flex-col md:flex-row items-center justify-between gap-4">
+    <div class="max-w-6xl mx-auto px-4 text-center">
       <p class="text-sm text-slate-500">© <span id="year"></span> ชื่อของคุณ — All rights reserved.</p>
-      <div class="flex gap-4 text-slate-500">
+      <div class="mt-4 flex gap-4 justify-center text-slate-500">
         <a href="#home" class="underline">กลับขึ้นด้านบน</a>
       </div>
     </div>
@@ -245,11 +226,6 @@
       const isDark = root.classList.contains('dark');
       localStorage.setItem('theme', isDark ? 'dark' : 'light');
       themeToggle.textContent = isDark ? 'โหมดสว่าง' : 'โหมดมืด';
-    });
-
-    // Mobile menu
-    document.getElementById('menuBtn').addEventListener('click', () => {
-      document.getElementById('mobileMenu').classList.toggle('hidden');
     });
 
     // No contact form needed; keep a helper for copying email


### PR DESCRIPTION
## Summary
- Center navigation and remove mobile menu for a balanced header
- Rebuild hero with centered profile and actions for symmetry
- Align about, projects, skills, contact, and footer sections centrally for cohesive design

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c81e9f35d8832db04a5fac3eff5390